### PR TITLE
カウントダウン実装

### DIFF
--- a/src/components/CountDown/CountDown/CountDown.tsx
+++ b/src/components/CountDown/CountDown/CountDown.tsx
@@ -16,19 +16,23 @@ export const CountDown = ({
       )}
       {...rest}
     >
-      <span className=" col-span-2 mb-[16px] self-end text-center font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f]">
+      <span className=" col-span-2 mb-[16px] self-end text-center font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f] sm:text-[48px] sm:leading-[56px]">
         開催まで
       </span>
 
       <div className="flex items-end">
-        <span className="mb-[30px] mr-[16px] font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f] [-webkit-text-stroke:0.3px_white]">
+        {/* [-webkit-text-stroke]がsm:をつけても重複判定されるため無効化 */}
+        {/* eslint-disable-next-line tailwindcss/no-contradicting-classname */}
+        <span className="mb-[30px] mr-[16px] font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f] [-webkit-text-stroke:0.3px_white] sm:text-[48px] sm:leading-[56px] sm:[-webkit-text-stroke:1px_white]">
           あと
         </span>
         <FlipCalendar>{leftNum}</FlipCalendar>
       </div>
       <div className="flex items-end">
         <FlipCalendar>{rightNum}</FlipCalendar>
-        <span className="ml-[16px] mb-[30px] font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f] [-webkit-text-stroke:0.3px_white]">
+        {/* [-webkit-text-stroke]がsm:をつけても重複判定されるため無効化 */}
+        {/* eslint-disable-next-line tailwindcss/no-contradicting-classname */}
+        <span className="ml-[16px] mb-[30px] font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f] [-webkit-text-stroke:0.3px_white] sm:text-[48px] sm:leading-[56px] sm:[-webkit-text-stroke:1px_white]">
           日
         </span>
       </div>

--- a/src/components/CountDown/CountDown/CountDown.tsx
+++ b/src/components/CountDown/CountDown/CountDown.tsx
@@ -11,12 +11,12 @@ export const CountDown = ({
   return (
     <div
       className={clsx(
-        'grid w-fit auto-rows-min grid-cols-2 grid-rows-[min-content_minmax(0,_1fr)]',
+        'grid w-fit select-none auto-rows-min grid-cols-2 grid-rows-[min-content_minmax(0,_1fr)]',
         className
       )}
       {...rest}
     >
-      <span className=" col-span-2 mb-[16px] self-end text-center font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f] sm:text-[48px] sm:leading-[56px]">
+      <span className="col-span-2 mb-[16px] self-end text-center font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f] sm:text-[48px] sm:leading-[56px]">
         開催まで
       </span>
 

--- a/src/components/CountDown/CountDown/CountDown.tsx
+++ b/src/components/CountDown/CountDown/CountDown.tsx
@@ -1,1 +1,37 @@
-export const CountDown = () => <>CountDown</>;
+import { ComponentPropsWithoutRef } from 'react';
+import clsx from 'clsx';
+import { FlipCalendar } from '../FlipCalendar';
+import { useCountDown } from 'hooks/useCountDown';
+
+export const CountDown = ({
+  className,
+  ...rest
+}: ComponentPropsWithoutRef<'div'>) => {
+  const [leftNum, rightNum] = useCountDown();
+  return (
+    <div
+      className={clsx(
+        'grid w-fit auto-rows-min grid-cols-2 grid-rows-[min-content_minmax(0,_1fr)]',
+        className
+      )}
+      {...rest}
+    >
+      <span className=" col-span-2 mb-[16px] self-end text-center font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f]">
+        開催まで
+      </span>
+
+      <div className="flex items-end">
+        <span className="mb-[30px] mr-[16px] font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f] [-webkit-text-stroke:0.3px_white]">
+          あと
+        </span>
+        <FlipCalendar>{leftNum}</FlipCalendar>
+      </div>
+      <div className="flex items-end">
+        <FlipCalendar>{rightNum}</FlipCalendar>
+        <span className="ml-[16px] mb-[30px] font-[Roboto] text-[24px] font-bold leading-[28px] text-[#18283f] [-webkit-text-stroke:0.3px_white]">
+          日
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/CountDown/FlipCalendar/FlipCalendar.stories.tsx
+++ b/src/components/CountDown/FlipCalendar/FlipCalendar.stories.tsx
@@ -4,9 +4,17 @@ import { FlipCalendar } from './FlipCalendar';
 
 export default {
   component: FlipCalendar,
+  argTypes: {
+    children: { control: 'text' },
+  },
 } as ComponentMeta<typeof FlipCalendar>;
 
-const Template: ComponentStory<typeof FlipCalendar> = () => <FlipCalendar />;
+const Template: ComponentStory<typeof FlipCalendar> = (args) => (
+  <FlipCalendar {...args} />
+);
 
 // eslint-disable-next-line storybook/prefer-pascal-case
 export const flipCalendar = Template.bind({});
+flipCalendar.args = {
+  children: '0',
+};

--- a/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
+++ b/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
@@ -13,7 +13,7 @@ export const FlipCalendar = ({
   return (
     <div
       className={clsx(
-        'relative h-[110px] w-[70px] sm:h-[220px] sm:w-[140px]',
+        'relative h-[110px] w-[70px] select-none sm:h-[220px] sm:w-[140px]',
         className
       )}
       {...rest}

--- a/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
+++ b/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
@@ -24,7 +24,7 @@ export const FlipCalendar = ({
         width={isMobile ? 70 : 140}
         height={isMobile ? 110 : 220}
       />
-      <p className="absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] font-[Roboto] text-[48px] font-bold leading-[56px] sm:text-[88px] sm:leading-[104px]">
+      <p className="absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] font-[Roboto] text-[48px] font-bold leading-[56px] text-[#18283f] sm:text-[88px] sm:leading-[104px]">
         {children}
       </p>
     </div>

--- a/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
+++ b/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
@@ -1,1 +1,16 @@
-export const FlipCalendar = () => <>FlipCalendar</>;
+import { ComponentPropsWithoutRef } from 'react';
+import Image from 'next/image';
+import clsx from 'clsx';
+
+export const FlipCalendar = ({
+  className,
+  children,
+  ...rest
+}: ComponentPropsWithoutRef<'div'>) => (
+  <div className={clsx('relative h-[140px] w-[70px]', className)} {...rest}>
+    <Image src="/flip_clock.png" alt="カウントダウン" width={70} height={140} />
+    <p className="absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] font-[Roboto] text-[48px] font-bold leading-[56px]">
+      {children}
+    </p>
+  </div>
+);

--- a/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
+++ b/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
@@ -1,16 +1,32 @@
 import { ComponentPropsWithoutRef } from 'react';
 import Image from 'next/image';
 import clsx from 'clsx';
+import { useMobileView } from 'hooks/useMobileView';
 
 export const FlipCalendar = ({
   className,
   children,
   ...rest
-}: ComponentPropsWithoutRef<'div'>) => (
-  <div className={clsx('relative h-[110px] w-[70px]', className)} {...rest}>
-    <Image src="/flip_clock.png" alt="カウントダウン" width={70} height={110} />
-    <p className="absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] font-[Roboto] text-[48px] font-bold leading-[56px]">
-      {children}
-    </p>
-  </div>
-);
+}: ComponentPropsWithoutRef<'div'>) => {
+  const isMobile = useMobileView();
+
+  return (
+    <div
+      className={clsx(
+        'relative h-[110px] w-[70px] sm:h-[220px] sm:w-[140px]',
+        className
+      )}
+      {...rest}
+    >
+      <Image
+        src="/flip_clock.png"
+        alt="カウントダウン"
+        width={isMobile ? 70 : 140}
+        height={isMobile ? 110 : 220}
+      />
+      <p className="absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] font-[Roboto] text-[48px] font-bold leading-[56px] sm:text-[88px] sm:leading-[104px]">
+        {children}
+      </p>
+    </div>
+  );
+};

--- a/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
+++ b/src/components/CountDown/FlipCalendar/FlipCalendar.tsx
@@ -7,8 +7,8 @@ export const FlipCalendar = ({
   children,
   ...rest
 }: ComponentPropsWithoutRef<'div'>) => (
-  <div className={clsx('relative h-[140px] w-[70px]', className)} {...rest}>
-    <Image src="/flip_clock.png" alt="カウントダウン" width={70} height={140} />
+  <div className={clsx('relative h-[110px] w-[70px]', className)} {...rest}>
+    <Image src="/flip_clock.png" alt="カウントダウン" width={70} height={110} />
     <p className="absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] font-[Roboto] text-[48px] font-bold leading-[56px]">
       {children}
     </p>

--- a/src/hooks/useCountDown/useCountDown.ts
+++ b/src/hooks/useCountDown/useCountDown.ts
@@ -1,1 +1,16 @@
-export const useCountDown = () => {};
+/**
+ * useCountDownはシステムの現在日時から日本時間2022年11月5日までの日数を返します
+ * 返り値は必要に応じて0でpaddingされ常に2桁になります
+ */
+export const useCountDown = () => {
+  const msPerDay = 24 * 60 * 60 * 1000;
+
+  const now = Date.now();
+  const target = Date.UTC(2022, 10, 4, 15, 0, 0);
+  const daysLeft = Math.floor((target - now) / msPerDay);
+
+  const daysLeftStr =
+    daysLeft < 0 ? '00' : daysLeft.toString().padStart(2, '0');
+
+  return [daysLeftStr.slice(0, 1), daysLeftStr.slice(1, 2)] as const;
+};

--- a/src/hooks/useMobileView/index.ts
+++ b/src/hooks/useMobileView/index.ts
@@ -1,0 +1,1 @@
+export * from './useMobileView';

--- a/src/hooks/useMobileView/useMobileView.ts
+++ b/src/hooks/useMobileView/useMobileView.ts
@@ -1,0 +1,25 @@
+import { useEffect, useReducer } from 'react';
+
+/**
+ * useMobileView はページを閲覧しているデバイスがモバイル端末であるかどうかを判定します
+ * モバイル端末のとき true、そうでないとき false を返します
+ */
+export const useMobileView = () => {
+  const breakPoint = 639;
+
+  const [matches, setMatches] = useReducer(
+    () =>
+      window ? window.matchMedia(`(max-width:${breakPoint}px)`).matches : true,
+    true
+  );
+
+  useEffect(() => {
+    const matchMedia = window.matchMedia(`(max-width:${breakPoint}px)`);
+    matchMedia.addEventListener('change', setMatches);
+    setMatches();
+
+    return () => matchMedia.removeEventListener('change', setMatches);
+  }, []);
+
+  return matches;
+};


### PR DESCRIPTION
3 機能実装しました。
* カウントダウン`CountDown`
* `CountDown`の内部で使用している`FlipCalendar`
* カウントダウンのロジック`useCountDown`

`useMobileView`は #38 の実装をそのまま流用しています。
#41 で一本化する予定です。
また、日数が微妙に違うような気がしますがその調査・改善は不要不急なので #42 としました。

`CountDown`では、「開催」と「まで」の間・日数の十の位と一の位の間が横幅の中央になるよう実装しています。

`FlipCalendar`中央の文字は紺ではなく黒ですがデザインデータ通りです。