### PR TITLE
ヘッダ実装 #7

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,1 +1,13 @@
-export const Header = () => <>Header</>;
+import clsx from 'clsx';
+import { HomeButton, MenuButton } from 'components/Button';
+
+export const Header = ({ className }: { className?: string }) => (
+  <div className={clsx('fixed z-10 flex w-full justify-between', className)}>
+    <HomeButton className="ml-[16px] sm:ml-[56px]" />
+    <MenuButton
+      className="mr-[16px] sm:mr-[56px]"
+      // TODO: メニュー実装時に disabled 解除
+      disabled
+    />
+  </div>
+);


### PR DESCRIPTION
Close #7 .

ヘッダを実装しました。

一応`zIndex`は指定したのでこのまま配置しても浮くようになっています（`className`で上書き可）。

`MenuButton`の`props`は`Header`の`props`で指定可能にする必要が無いかなと思ったため、ここで`disabled`にしています。
メニューを適用する時 #27 `disabled`を解除します。