### PR TITLE
`LinkButton`実装

### DIFF
--- a/src/components/Button/LinkButton/LinkButton.stories.tsx
+++ b/src/components/Button/LinkButton/LinkButton.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { link } from 'fs/promises';
+
+import { LinkButton } from './LinkButton';
+
+export default {
+  component: LinkButton,
+} as ComponentMeta<typeof LinkButton>;
+
+const Template: ComponentStory<typeof LinkButton> = (args) => (
+  <LinkButton {...args} />
+);
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const linkButton = Template.bind({});
+linkButton.args = {
+  text: 'もっと見る',
+  disabled: false,
+  onClick: () => {},
+  className: '',
+};

--- a/src/components/Button/LinkButton/LinkButton.stories.tsx
+++ b/src/components/Button/LinkButton/LinkButton.stories.tsx
@@ -14,17 +14,19 @@ const Template: ComponentStory<typeof LinkButton> = (args) => (
 // eslint-disable-next-line storybook/prefer-pascal-case
 export const seeMoreButton = Template.bind({});
 seeMoreButton.args = {
-  text: 'もっと見る',
+  href: '/news',
+  children: 'もっと見る',
   disabled: false,
   onClick: () => {},
-  className: 'border border-solid border-[#18283F] text-[#18283F]',
+  className: 'border border-solid border-[#18283F] text-[#18283F] font-bold',
 };
 
 // eslint-disable-next-line storybook/prefer-pascal-case
 export const contactButton = Template.bind({});
 contactButton.args = {
-  text: 'お問い合わせ',
+  href: '/contact',
+  children: 'お問い合わせ',
   disabled: false,
   onClick: () => {},
-  className: 'bg-[#18283F] text-white',
+  className: 'bg-[#18283F] text-white font-bold',
 };

--- a/src/components/Button/LinkButton/LinkButton.stories.tsx
+++ b/src/components/Button/LinkButton/LinkButton.stories.tsx
@@ -12,10 +12,19 @@ const Template: ComponentStory<typeof LinkButton> = (args) => (
 );
 
 // eslint-disable-next-line storybook/prefer-pascal-case
-export const linkButton = Template.bind({});
-linkButton.args = {
+export const seeMoreButton = Template.bind({});
+seeMoreButton.args = {
   text: 'もっと見る',
   disabled: false,
   onClick: () => {},
-  className: '',
+  className: 'border border-solid border-[#18283F] text-[#18283F]',
+};
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const contactButton = Template.bind({});
+contactButton.args = {
+  text: 'お問い合わせ',
+  disabled: false,
+  onClick: () => {},
+  className: 'bg-[#18283F] text-white',
 };

--- a/src/components/Button/LinkButton/LinkButton.stories.tsx
+++ b/src/components/Button/LinkButton/LinkButton.stories.tsx
@@ -1,6 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { link } from 'fs/promises';
-
 import { LinkButton } from './LinkButton';
 
 export default {
@@ -11,9 +9,8 @@ const Template: ComponentStory<typeof LinkButton> = (args) => (
   <LinkButton {...args} />
 );
 
-// eslint-disable-next-line storybook/prefer-pascal-case
-export const seeMoreButton = Template.bind({});
-seeMoreButton.args = {
+export const SeeMoreButton = Template.bind({});
+SeeMoreButton.args = {
   href: '/news',
   children: 'もっと見る',
   disabled: false,
@@ -21,9 +18,8 @@ seeMoreButton.args = {
   className: 'border border-solid border-[#18283F] text-[#18283F] font-bold',
 };
 
-// eslint-disable-next-line storybook/prefer-pascal-case
-export const contactButton = Template.bind({});
-contactButton.args = {
+export const ContactButton = Template.bind({});
+ContactButton.args = {
   href: '/contact',
   children: 'お問い合わせ',
   disabled: false,

--- a/src/components/Button/LinkButton/LinkButton.tsx
+++ b/src/components/Button/LinkButton/LinkButton.tsx
@@ -1,5 +1,7 @@
 import clsx from 'clsx';
+import { useRouter } from 'next/router';
 import { ComponentPropsWithoutRef } from 'react';
+import { Url } from 'url';
 
 const RightCircleArrow = (props: ComponentPropsWithoutRef<'svg'>) => (
   <svg viewBox="0 0 16 16" {...props}>
@@ -21,20 +23,29 @@ const RightCircleArrow = (props: ComponentPropsWithoutRef<'svg'>) => (
 );
 
 export const LinkButton = ({
-  text,
+  href,
+  onClick,
+  children,
   className,
   ...restProps
-}: { text: string } & ComponentPropsWithoutRef<'button'>) => (
-  <button
-    className={clsx(
-      'inline-flex h-8 w-36 select-none items-center justify-center gap-x-2 rounded-full px-4',
-      className
-    )}
-    {...restProps}
-  >
-    <span className="flex-auto text-ellipsis whitespace-nowrap text-center align-middle text-xs font-bold">
-      {text}
-    </span>
-    <RightCircleArrow className="h-4 w-4" />
-  </button>
-);
+}: ComponentPropsWithoutRef<'button'> & { href: string }) => {
+  const router = useRouter();
+  return (
+    <button
+      onClick={(e) => {
+        router.push(href);
+        onClick && onClick(e);
+      }}
+      className={clsx(
+        'inline-flex h-8 w-36 select-none items-center justify-center gap-x-2 rounded-full px-4',
+        className
+      )}
+      {...restProps}
+    >
+      <span className="flex-auto text-ellipsis whitespace-nowrap text-center align-middle text-xs">
+        {children}
+      </span>
+      <RightCircleArrow className="h-4 w-4" />
+    </button>
+  );
+};

--- a/src/components/Button/LinkButton/LinkButton.tsx
+++ b/src/components/Button/LinkButton/LinkButton.tsx
@@ -27,7 +27,7 @@ export const LinkButton = ({
 }: { text: string } & ComponentPropsWithoutRef<'button'>) => (
   <button
     className={clsx(
-      'inline-flex h-8 w-36 select-none items-center justify-center gap-x-2 rounded-full border border-solid border-[#18283F] px-4',
+      'inline-flex h-8 w-36 select-none items-center justify-center gap-x-2 rounded-full px-4',
       className
     )}
     {...restProps}

--- a/src/components/Button/LinkButton/LinkButton.tsx
+++ b/src/components/Button/LinkButton/LinkButton.tsx
@@ -1,0 +1,40 @@
+import clsx from 'clsx';
+import { ComponentPropsWithoutRef } from 'react';
+
+const RightCircleArrow = (props: ComponentPropsWithoutRef<'svg'>) => (
+  <svg viewBox="0 0 16 16" {...props}>
+    <circle
+      cx="8"
+      cy="8"
+      r="7"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1}
+    />
+    <polyline
+      points="4.5,4.5 11.5,8 4.5,11.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1}
+    />
+  </svg>
+);
+
+export const LinkButton = ({
+  text,
+  className,
+  ...restProps
+}: { text: string } & ComponentPropsWithoutRef<'button'>) => (
+  <button
+    className={clsx(
+      'inline-flex h-8 w-36 select-none items-center justify-center gap-x-2 rounded-full border border-solid border-[#18283F] px-4',
+      className
+    )}
+    {...restProps}
+  >
+    <span className="flex-auto text-ellipsis whitespace-nowrap text-center align-middle text-xs font-bold">
+      {text}
+    </span>
+    <RightCircleArrow className="h-4 w-4" />
+  </button>
+);

--- a/src/components/Button/LinkButton/LinkButton.tsx
+++ b/src/components/Button/LinkButton/LinkButton.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import { ComponentPropsWithoutRef } from 'react';
-import { Url } from 'url';
 
 const RightCircleArrow = (props: ComponentPropsWithoutRef<'svg'>) => (
   <svg viewBox="0 0 16 16" {...props}>
@@ -28,12 +27,12 @@ export const LinkButton = ({
   children,
   className,
   ...restProps
-}: ComponentPropsWithoutRef<'button'> & { href: string }) => {
+}: ComponentPropsWithoutRef<'button'> & { href?: string }) => {
   const router = useRouter();
   return (
     <button
       onClick={(e) => {
-        router.push(href);
+        href && router.push(href);
         onClick && onClick(e);
       }}
       className={clsx(

--- a/src/components/Button/LinkButton/index.ts
+++ b/src/components/Button/LinkButton/index.ts
@@ -1,0 +1,1 @@
+export * from './LinkButton';

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,3 +1,4 @@
 export * from './HomeButton';
 export * from './MenuButton';
 export * from './RoundedButton';
+export * from './LinkButton';


### PR DESCRIPTION
レスポンシブ対応はデザインがないのでまだですが、形にはなったと思います。

- 遷移先は追加した`href`プロパティから指定します。

### `next/link`にしなかった理由

`LinkProps`がうまく扱えなかったから。

実装が想定しているものと合っているか確認お願いします。