### PR TITLE
SmallLink実装 #24

### DIFF
--- a/src/components/Link/SmallLink/SmallLink.stories.tsx
+++ b/src/components/Link/SmallLink/SmallLink.stories.tsx
@@ -1,0 +1,22 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { SmallLink } from './SmallLink';
+
+export default {
+  component: SmallLink,
+  argTypes: {
+    href: { control: 'text' },
+    children: { control: 'text' },
+  },
+} as ComponentMeta<typeof SmallLink>;
+
+const Template: ComponentStory<typeof SmallLink> = (args) => (
+  <SmallLink {...args} />
+);
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const smallLink = Template.bind({});
+smallLink.args = {
+  href: '/',
+  children: 'プライバシーポリシー',
+};

--- a/src/components/Link/SmallLink/SmallLink.tsx
+++ b/src/components/Link/SmallLink/SmallLink.tsx
@@ -1,0 +1,22 @@
+import { ComponentPropsWithoutRef } from 'react';
+import Link from 'next/link';
+import clsx from 'clsx';
+
+export const SmallLink = ({
+  children,
+  className,
+  href,
+  ...restProps
+}: ComponentPropsWithoutRef<'a'> & { href: string }) => (
+  <Link href={href}>
+    <a
+      className={clsx(
+        'font-[Roboto] text-[0.625rem] font-light leading-3 text-[#18283f] underline underline-offset-2',
+        className
+      )}
+      {...restProps}
+    >
+      {children}
+    </a>
+  </Link>
+);

--- a/src/components/Link/SmallLink/index.ts
+++ b/src/components/Link/SmallLink/index.ts
@@ -1,0 +1,1 @@
+export * from './SmallLink';

--- a/src/components/Link/index.ts
+++ b/src/components/Link/index.ts
@@ -1,0 +1,1 @@
+export * from './SmallLink';


### PR DESCRIPTION
Close #24 .

デザインデータではテキストと下線の間に僅かに隙間があるように見えたので、（デザインデータのCSSプロパティには存在しませんが）`text-underline-offset`を設定しました。