### PR TITLE
協賛一覧実装 #32

### DIFF
--- a/src/components/Sponsor/SponsorList/SponsorList.stories.tsx
+++ b/src/components/Sponsor/SponsorList/SponsorList.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { SponsorList } from './SponsorList';
+
+export default {
+  component: SponsorList,
+} as ComponentMeta<typeof SponsorList>;
+
+const Template: ComponentStory<typeof SponsorList> = () => <SponsorList />;
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const sponsorList = Template.bind({});

--- a/src/components/Sponsor/SponsorList/SponsorList.tsx
+++ b/src/components/Sponsor/SponsorList/SponsorList.tsx
@@ -1,0 +1,13 @@
+import clsx from 'clsx';
+import { Heading } from 'components/Typography';
+import { ComponentPropsWithoutRef } from 'react';
+
+export const SponsorList = ({
+  children,
+  ...restProps
+}: ComponentPropsWithoutRef<'article'>) => (
+  <article {...restProps}>
+    <Heading className="text-center">協賛いただいた企業・団体</Heading>
+    {children}
+  </article>
+);

--- a/src/components/Sponsor/SponsorList/index.ts
+++ b/src/components/Sponsor/SponsorList/index.ts
@@ -1,0 +1,1 @@
+export * from './SponsorList';

--- a/src/components/Sponsor/index.ts
+++ b/src/components/Sponsor/index.ts
@@ -1,0 +1,1 @@
+export * from './SponsorList';


### PR DESCRIPTION
Close #32 .

`SponsorList`を実装しました。
このコンポーネントで決めているのは見出しだけで、内容は使用者が`children`で指定可能になっています。

一覧のコンテンツ次第ですが、`SponsorList`は協賛企業・団体様のデータを与えるコンポーネントになるかもしれません。その際は内容を`children`で指定するのではなくこのコンポーネントに直接書き込む実装に変更することになると思います。

いずれにせよ、現時点では内容が空なので特に何も配置していません。