### PR TITLE
MenuContext実装 #26

### DIFF
--- a/src/contexts/MenuContext/MenuContext.tsx
+++ b/src/contexts/MenuContext/MenuContext.tsx
@@ -4,21 +4,22 @@ export const MenuOpenContext = createContext(false);
 
 export const ToggleMenuContext = createContext(() => {});
 
+export const CloseMenuContext = createContext(() => {});
+
 export const MenuContextProvider = ({ children }: { children: ReactNode }) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const toggleMenuOpen = useCallback(
-    () =>
-      setMenuOpen((prev) => {
-        console.log('toggleMenuOpen');
-        return !prev;
-      }),
+    () => setMenuOpen((prev) => !prev),
     [setMenuOpen]
   );
+  const closeMenuOpen = useCallback(() => setMenuOpen(false), [setMenuOpen]);
 
   return (
     <MenuOpenContext.Provider value={menuOpen}>
       <ToggleMenuContext.Provider value={toggleMenuOpen}>
-        {children}
+        <CloseMenuContext.Provider value={closeMenuOpen}>
+          {children}
+        </CloseMenuContext.Provider>
       </ToggleMenuContext.Provider>
     </MenuOpenContext.Provider>
   );

--- a/src/contexts/MenuContext/MenuContext.tsx
+++ b/src/contexts/MenuContext/MenuContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, ReactNode, useCallback, useState } from 'react';
+
+export const MenuOpenContext = createContext(false);
+
+export const ToggleMenuContext = createContext(() => {});
+
+export const MenuContextProvider = ({ children }: { children: ReactNode }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const toggleMenuOpen = useCallback(
+    () =>
+      setMenuOpen((prev) => {
+        console.log('toggleMenuOpen');
+        return !prev;
+      }),
+    [setMenuOpen]
+  );
+
+  return (
+    <MenuOpenContext.Provider value={menuOpen}>
+      <ToggleMenuContext.Provider value={toggleMenuOpen}>
+        {children}
+      </ToggleMenuContext.Provider>
+    </MenuOpenContext.Provider>
+  );
+};

--- a/src/contexts/MenuContext/index.ts
+++ b/src/contexts/MenuContext/index.ts
@@ -1,0 +1,1 @@
+export * from './MenuContext';

--- a/src/hooks/useCloseMenu/index.ts
+++ b/src/hooks/useCloseMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './useCloseMenu';

--- a/src/hooks/useCloseMenu/useCloseMenu.ts
+++ b/src/hooks/useCloseMenu/useCloseMenu.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { CloseMenuContext } from 'contexts/MenuContext';
+
+/**
+ * useCloseMenu はメニューを閉じる関数を返します
+ */
+export const useCloseMenu = () => {
+  return useContext(CloseMenuContext);
+};

--- a/src/hooks/useMenuOpen/index.ts
+++ b/src/hooks/useMenuOpen/index.ts
@@ -1,0 +1,1 @@
+export * from './useMenuOpen';

--- a/src/hooks/useMenuOpen/useMenuOpen.ts
+++ b/src/hooks/useMenuOpen/useMenuOpen.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { MenuOpenContext } from 'contexts/MenuContext';
+
+/**
+ * useMenuOpen はメニューの開閉状態の state を返します
+ */
+export const useMenuOpen = () => {
+  return useContext(MenuOpenContext);
+};

--- a/src/hooks/useToggleMenu/index.ts
+++ b/src/hooks/useToggleMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './useToggleMenu';

--- a/src/hooks/useToggleMenu/useToggleMenu.ts
+++ b/src/hooks/useToggleMenu/useToggleMenu.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { ToggleMenuContext } from 'contexts/MenuContext';
+
+/**
+ * useToggleMenu はメニューの開閉状態を切り替える関数を返します
+ */
+export const useToggleMenu = () => {
+  return useContext(ToggleMenuContext);
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import 'styles/globals.css';
 import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import { ReactElement, ReactNode } from 'react';
+import { MenuContextProvider } from 'contexts/MenuContext';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -11,5 +12,9 @@ type AppPropsWithLayout = AppProps & { Component: NextPageWithLayout };
 
 export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout ?? ((page) => page);
-  return getLayout(<Component {...pageProps} />);
+  return getLayout(
+    <MenuContextProvider>
+      <Component {...pageProps} />
+    </MenuContextProvider>
+  );
 }


### PR DESCRIPTION
メニューの開閉状態の`state`とそれを toggle する関数を`Context`でアクセスできるようにしました。
UI の変更はないのでロジックだけ確認していただければと思います。

メニューの開閉状態の`state`を使用する場合は`useMenuOpen`、メニューの開閉状態を toggle する関数を使用する場合は`useToggleMenu`を使用すれば良いように作成しました。

```ts
// state を使う場合
const menuOpen = useMenuOpen();

// toggle 関数を使う場合
const toggleMenu = useToggleMenu();
```