### PR TITLE
メニュー実装 #25

### DIFF
--- a/src/components/Menu/MenuDrawer/MenuDrawer.stories.tsx
+++ b/src/components/Menu/MenuDrawer/MenuDrawer.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { MenuDrawer } from './MenuDrawer';
+
+export default {
+  component: MenuDrawer,
+} as ComponentMeta<typeof MenuDrawer>;
+
+const Template: ComponentStory<typeof MenuDrawer> = () => <MenuDrawer />;
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const menuDrawer = Template.bind({});

--- a/src/components/Menu/MenuDrawer/MenuDrawer.tsx
+++ b/src/components/Menu/MenuDrawer/MenuDrawer.tsx
@@ -1,0 +1,97 @@
+import { ComponentPropsWithoutRef } from 'react';
+import Image from 'next/image';
+import clsx from 'clsx';
+import { Copyright } from 'components/Copyright';
+import { MenuLink } from 'components/Link';
+import { Paragraph } from 'components/Typography';
+import { useMobileView } from 'hooks/useMobileView';
+
+export const MenuDrawer = ({
+  className,
+  ...restProps
+}: ComponentPropsWithoutRef<'nav'>) => {
+  const isMobile = useMobileView();
+
+  return (
+    <nav
+      className={clsx(
+        'min-h-full min-w-full bg-[#edbd83] px-[24px] pt-[80px] sm:flex sm:flex-col sm:items-center',
+        className
+      )}
+      {...restProps}
+    >
+      <div className="sm:flex sm:items-center">
+        {!isMobile && (
+          <div>
+            <Image
+              src="/kougakusai_title.png"
+              alt="こうがく祭タイトル"
+              width={320}
+              height={180}
+            />
+          </div>
+        )}
+        <div className="sm:ml-[32px]">
+          <Paragraph className="font-bold">
+            <span className="text-[1.5rem] leading-6 sm:text-[2.5rem] sm:leading-[3rem]">
+              2022.11.05
+            </span>
+            <Space />
+            <span className="sm:text-[1.5rem] sm:leading-6">土曜日</span>
+          </Paragraph>
+          <Paragraph className="mt-[16px] font-bold sm:text-[1.5rem] sm:leading-6">
+            <MapPinIcon className="mr-[4px] inline-block sm:mr-[8px]" />
+            茨城大学工学部キャンパス
+            <Space />/<Space />
+            入場料無料
+          </Paragraph>
+        </div>
+      </div>
+      <ul className="mt-[32px] grid grid-cols-1 gap-y-[32px] sm:mt-[128px] sm:grid-cols-2 sm:gap-y-[48px] sm:gap-x-[96px]">
+        {links.map((link) => (
+          <li key={link.href}>
+            <MenuLink href={link.href}>{link.name}</MenuLink>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-[40px] sm:mt-[120px]">
+        <Image
+          src="/kougakusai_banner.png"
+          alt="こうがく祭バナー"
+          width={isMobile ? 370 : 590}
+          height={isMobile ? 150 : 240}
+        />
+      </div>
+      <Copyright className="block py-[24px] text-center sm:pb-[40px]" />
+    </nav>
+  );
+};
+
+const links = [
+  { name: 'トップ', href: '/' },
+  { name: 'こうがく祭について', href: '/about' },
+  { name: 'タイムスケジュール', href: '/schedule' },
+  { name: 'アクセス', href: '/access' },
+  { name: 'お問い合わせ', href: '/contact' },
+];
+
+// https://heroicons.com/
+const MapPinIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={clsx('h-6 w-6', className)}
+  >
+    <path
+      fillRule="evenodd"
+      d="M11.54 22.351l.07.04.028.016a.76.76 0 00.723 0l.028-.015.071-.041a16.975 16.975 0 001.144-.742 19.58 19.58 0 002.683-2.282c1.944-1.99 3.963-4.98 3.963-8.827a8.25 8.25 0 00-16.5 0c0 3.846 2.02 6.837 3.963 8.827a19.58 19.58 0 002.682 2.282 16.975 16.975 0 001.145.742zM12 13.5a3 3 0 100-6 3 3 0 000 6z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+const Space = () => {
+  const isMobile = useMobileView();
+  return isMobile ? <>&nbsp;</> : <>&emsp;</>;
+};

--- a/src/components/Menu/MenuDrawer/index.ts
+++ b/src/components/Menu/MenuDrawer/index.ts
@@ -1,0 +1,1 @@
+export * from './MenuDrawer';

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -1,0 +1,1 @@
+export * from './MenuDrawer';


### PR DESCRIPTION
Close #25 .

メニューを実装しました。
PC版ではリンクの並び順がデザインと異なっていますが、`grid-auto-flow`を`column`にすればデザインデータに合わせることも可能です。