### PR TITLE
お知らせ実装 #29

### DIFF
--- a/src/components/Notification/NotificationItem/NotificationItem.stories.tsx
+++ b/src/components/Notification/NotificationItem/NotificationItem.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { NotificationItem } from './NotificationItem';
+
+export default {
+  component: NotificationItem,
+} as ComponentMeta<typeof NotificationItem>;
+
+const Template: ComponentStory<typeof NotificationItem> = (args) => (
+  <NotificationItem {...args} />
+);
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const notificationItem = Template.bind({});
+notificationItem.args = {
+  date: '2022/9/22',
+  category: 'その他',
+  text: 'HPが公開されました。',
+};

--- a/src/components/Notification/NotificationItem/NotificationItem.tsx
+++ b/src/components/Notification/NotificationItem/NotificationItem.tsx
@@ -1,0 +1,23 @@
+import { ComponentPropsWithoutRef } from 'react';
+import clsx from 'clsx';
+import { Paragraph, Small } from 'components/Typography';
+
+export const NotificationItem = ({
+  date,
+  category,
+  text,
+  className,
+}: ComponentPropsWithoutRef<'div'> & {
+  date: string;
+  category: string;
+  text: string;
+}) => (
+  <div className={clsx('', className)}>
+    <div className="flex gap-[8px]">
+      <Small>{date}</Small>
+      <Small>|</Small>
+      <Small>{category}</Small>
+    </div>
+    <Paragraph className="mt-[8px]">{text}</Paragraph>
+  </div>
+);

--- a/src/components/Notification/NotificationItem/index.ts
+++ b/src/components/Notification/NotificationItem/index.ts
@@ -1,0 +1,1 @@
+export * from './NotificationItem';

--- a/src/components/Notification/index.ts
+++ b/src/components/Notification/index.ts
@@ -1,0 +1,1 @@
+export * from './NotificationItem';

--- a/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/src/components/Typography/Paragraph/Paragraph.tsx
@@ -8,7 +8,7 @@ export const Paragraph = ({
 }: ComponentPropsWithoutRef<'p'>) => (
   <p
     className={clsx(
-      'font-[Roboto] text-[1rem] font-bold leading-[1.125rem] text-[#18283F]',
+      'font-[Roboto] text-[1rem] leading-[1.125rem] text-[#18283F]',
       className
     )}
     {...restProps}


### PR DESCRIPTION
Close #29 .

お知らせを実装しました。
`Paragraph`の`font-weight`が間違っていたので修正しています（メニューで使用していますが影響はありません）。