### PR TITLE
「こうがく祭とは」実装 #31

### DIFF
--- a/src/components/About/About.stories.tsx
+++ b/src/components/About/About.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { About } from './About';
+
+export default {
+  component: About,
+} as ComponentMeta<typeof About>;
+
+const Template: ComponentStory<typeof About> = () => <About />;
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const about = Template.bind({});

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -1,0 +1,32 @@
+import { ComponentPropsWithoutRef } from 'react';
+import clsx from 'clsx';
+import { Marquee } from 'components/Marquee';
+import { Heading, Paragraph } from 'components/Typography';
+
+export const About = ({
+  className,
+  ...restProps
+}: ComponentPropsWithoutRef<'section'>) => (
+  <section
+    className={clsx('bg-[#aedf99] text-center', className)}
+    {...restProps}
+  >
+    <Marquee
+      direction="left"
+      text="KOUGAKUSAI"
+      className="mb-[24px] !font-[Roboto] !text-[2.5rem] !font-bold !text-white"
+      speed={50}
+    />
+    <Heading className="mb-[16px]">こうがく祭とは</Heading>
+    <Paragraph className="mb-[16px] font-bold">2022.11.05</Paragraph>
+    <Paragraph>こうがく祭は茨城大学工学部による学園祭です。</Paragraph>
+    <Paragraph>今年は3年ぶりの対面開催になります！</Paragraph>
+    <Paragraph>様々なサークル・研究室の企画をご覧ください。</Paragraph>
+    <Marquee
+      direction="right"
+      text="KOUGAKUSAI"
+      className="mt-[24px] !font-[Roboto] !text-[2.5rem] !font-bold !text-white"
+      speed={50}
+    />
+  </section>
+);

--- a/src/components/About/index.ts
+++ b/src/components/About/index.ts
@@ -1,0 +1,1 @@
+export * from './About';

--- a/src/components/Marquee/Marquee.tsx
+++ b/src/components/Marquee/Marquee.tsx
@@ -76,9 +76,14 @@ export const Marquee = ({
     right: 0;
 
     visibility: hidden;
-    animation: ${
-      direction === 'left' ? 'flowR2L' : 'flowL2R'
-    } ${flowTime}s linear infinite;
+  }
+
+  .animation-flowR2L {
+    animation: flowR2L ${flowTime}s linear infinite;
+  }
+
+  .animation-flowL2R {
+    animation: flowL2R ${flowTime}s linear infinite;
   }
 
   @keyframes flowR2L {
@@ -127,7 +132,10 @@ export const Marquee = ({
         {new Array(textCount || 1).fill(0).map((_, index) => (
           <div
             // eslint-disable-next-line tailwindcss/no-custom-classname
-            className="marquee-text"
+            className={clsx(
+              'marquee-text',
+              direction === 'left' ? 'animation-flowR2L' : 'animation-flowL2R'
+            )}
             style={{
               animationDelay: `${roundFirstDecimal(
                 (index * flowTime) / textCount


### PR DESCRIPTION
Close #31 .

「こうがく祭とは」を実装しました。
`Marquee`のバグ修正も含みます。

`<style>`は後から読み込まれたものが優先されるため、
最後に配置した`Marquee`の`direction`によって`.marquee-text`の`animation`の値が決まってしまい、`direction`の異なる`Marquee`が共存できていないようでした。
`direction`ごとにクラスを用意しクラス名を振り分けて対応しました。