### PR TITLE
`CopyButton`：クリップボードボタン実装 #79

### DIFF
--- a/src/components/Button/CopyButton/CopyButton.stories.tsx
+++ b/src/components/Button/CopyButton/CopyButton.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Popover } from 'components/Popover';
 
 import { CopyButton } from './CopyButton';
 
@@ -12,10 +13,4 @@ const Template: ComponentStory<typeof CopyButton> = (args) => (
 
 // eslint-disable-next-line storybook/prefer-pascal-case
 export const copyButton = Template.bind({});
-copyButton.args = {
-  /** コピーされるリンク */
-  link: 'http://kougakusai.eng.ibaraki.ac.jp/',
-  /** ハイパーリンクの表示テキスト */
-  text: 'こうがく祭',
-  title: 'こうがく祭公式サイトへのリンクをコピー',
-};
+copyButton.args = {};

--- a/src/components/Button/CopyButton/CopyButton.stories.tsx
+++ b/src/components/Button/CopyButton/CopyButton.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { CopyButton } from './CopyButton';
+
+export default {
+  component: CopyButton,
+} as ComponentMeta<typeof CopyButton>;
+
+const Template: ComponentStory<typeof CopyButton> = (args) => (
+  <CopyButton {...args} />
+);
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const copyButton = Template.bind({});
+copyButton.args = {
+  /** コピーされるリンク */
+  link: 'http://kougakusai.eng.ibaraki.ac.jp/',
+  /** ハイパーリンクの表示テキスト */
+  text: 'こうがく祭',
+  title: 'こうがく祭公式サイトへのリンクをコピー',
+};

--- a/src/components/Button/CopyButton/CopyButton.tsx
+++ b/src/components/Button/CopyButton/CopyButton.tsx
@@ -1,111 +1,41 @@
 import clsx from 'clsx';
+import { Popover } from 'components/Popover';
+import { useClipboardLink } from 'hooks/useClipboard';
 import { ComponentPropsWithoutRef, useState } from 'react';
 
-const popShowTime = 2; // [s]
-const copiedText = 'コピー完了';
-
-const useClipboardLink = (link: string, text?: string) => () =>
-  navigator.clipboard.write([
-    new ClipboardItem({
-      ['text/plain']: new Blob([link], { type: 'text/plain' }),
-      ['text/html']: new Blob([`<a href=${link}>${text || link}</a>`], {
-        type: 'text/html',
-      }),
-    }),
-  ]);
-
-// const useClipboardText = (text: string) => () =>
-//   navigator.clipboard.write([
-//     new ClipboardItem({
-//       ['text/plain']: new Blob([text], { type: 'text/plain' }),
-//     }),
-//   ]);
-
-/**
- * @param {String} link copy link
- * @param {String} text display text when hyper link
- */
 export const CopyButton = ({
-  link,
-  text,
   onClick,
   className,
-  title,
   ...restProps
-}: { link: string; text?: string } & Omit<
-  ComponentPropsWithoutRef<'button'>,
-  'children'
->) => {
-  const LinkToClipboard = useClipboardLink(link, text);
-  const handleCopy = () => {
+}: Omit<ComponentPropsWithoutRef<'button'>, 'children'>) => {
+  const [isDisabled, setIsDisabled] = useState(false);
+  const LinkToClipboard = useClipboardLink(
+    'http://kougakusai.eng.ibaraki.ac.jp/',
+    'こうがく祭公式サイト'
+  );
+  const handleClick = () => {
     LinkToClipboard()
-      .then(() => {
-        setIsPopShow(true);
-        setTimeout(() => setIsPopShow(false), popShowTime * 1000);
-      })
-      .catch(() =>
-        console.error('Something went wrong when copy to clipboard.')
-      );
-  };
-
-  const [isPopShow, setIsPopShow] = useState(false);
-  const Popover = () => {
-    const css = `
-    .popover {
-        animation: popShow ${popShowTime}s;
-        width: max-content;
-        position: absolute;
-        top: -0.125rem;
-        left: 50%;
-        transform: translate(-50%, 0);
-        display: hidden;
-        user-select: none;
-    }
-
-    @keyframes popShow {
-        0% {
-            transform: translate(-50%, 0);
-            opacity: 0;
-            display: flex;
-        }
-        25% {
-            transform: translate(-50%, -100%);
-            opacity: 1;
-        }
-        75% {
-            transform: translate(-50%, -100%);
-            opacity: 1;
-        }
-        100% {
-            transform: translate(-50%, 0);
-            opacity: 0;
-            display: hidden;
-        }
-    }
-    `;
-
-    return (
-      <>
-        <style>{css}</style>
-        {/* eslint-disable-next-line tailwindcss/no-custom-classname */}
-        <div className="popover text-[0.75rem] text-black">{copiedText}</div>
-      </>
-    );
+      .then(() => setIsDisabled(false))
+      .catch(() => {
+        setIsDisabled(true);
+        console.error('Something went wrong when copy to clipboard.');
+      });
   };
 
   return (
-    <button
-      onClick={(e) => {
-        handleCopy();
-        onClick && onClick(e);
-      }}
-      className={clsx('relative inline-flex h-9 w-9', className)}
-      title={title || `${text || link}へのリンクをコピー`}
-      {...restProps}
-    >
-      {isPopShow && <Popover />}
-      <ClipboardIcon />
-    </button>
+    <Popover popup="コピー完了" disable={isDisabled}>
+      <button
+        onClick={(e) => {
+          handleClick();
+          onClick && onClick(e);
+        }}
+        className={clsx('relative inline-flex h-9 w-9', className)}
+        title="こうがく祭公式サイトへのリンクをコピー"
+        {...restProps}
+      >
+        <ClipboardIcon />
+      </button>
+    </Popover>
   );
 };
 

--- a/src/components/Button/CopyButton/CopyButton.tsx
+++ b/src/components/Button/CopyButton/CopyButton.tsx
@@ -1,0 +1,137 @@
+import clsx from 'clsx';
+import { ComponentPropsWithoutRef, useState } from 'react';
+
+const popShowTime = 2; // [s]
+const copiedText = 'コピー完了';
+
+const useClipboardLink = (link: string, text?: string) => () =>
+  navigator.clipboard.write([
+    new ClipboardItem({
+      ['text/plain']: new Blob([link], { type: 'text/plain' }),
+      ['text/html']: new Blob([`<a href=${link}>${text || link}</a>`], {
+        type: 'text/html',
+      }),
+    }),
+  ]);
+
+// const useClipboardText = (text: string) => () =>
+//   navigator.clipboard.write([
+//     new ClipboardItem({
+//       ['text/plain']: new Blob([text], { type: 'text/plain' }),
+//     }),
+//   ]);
+
+/**
+ * @param {String} link copy link
+ * @param {String} text display text when hyper link
+ */
+export const CopyButton = ({
+  link,
+  text,
+  onClick,
+  className,
+  title,
+  ...restProps
+}: { link: string; text?: string } & Omit<
+  ComponentPropsWithoutRef<'button'>,
+  'children'
+>) => {
+  const LinkToClipboard = useClipboardLink(link, text);
+  const handleCopy = () => {
+    LinkToClipboard()
+      .then(() => {
+        setIsPopShow(true);
+        setTimeout(() => setIsPopShow(false), popShowTime * 1000);
+      })
+      .catch(() =>
+        console.error('Something went wrong when copy to clipboard.')
+      );
+  };
+
+  const [isPopShow, setIsPopShow] = useState(false);
+  const Popover = () => {
+    const css = `
+    .popover {
+        animation: popShow ${popShowTime}s;
+        width: max-content;
+        position: absolute;
+        top: -0.125rem;
+        left: 50%;
+        transform: translate(-50%, 0);
+        display: hidden;
+        user-select: none;
+    }
+
+    @keyframes popShow {
+        0% {
+            transform: translate(-50%, 0);
+            opacity: 0;
+            display: flex;
+        }
+        25% {
+            transform: translate(-50%, -100%);
+            opacity: 1;
+        }
+        75% {
+            transform: translate(-50%, -100%);
+            opacity: 1;
+        }
+        100% {
+            transform: translate(-50%, 0);
+            opacity: 0;
+            display: hidden;
+        }
+    }
+    `;
+
+    return (
+      <>
+        <style>{css}</style>
+        {/* eslint-disable-next-line tailwindcss/no-custom-classname */}
+        <div className="popover text-[0.75rem] text-black">{copiedText}</div>
+      </>
+    );
+  };
+
+  return (
+    <button
+      onClick={(e) => {
+        handleCopy();
+        onClick && onClick(e);
+      }}
+      className={clsx('relative inline-flex h-9 w-9', className)}
+      title={title || `${text || link}へのリンクをコピー`}
+      {...restProps}
+    >
+      {isPopShow && <Popover />}
+      <ClipboardIcon />
+    </button>
+  );
+};
+
+const ClipboardIcon = (
+  props: Omit<ComponentPropsWithoutRef<'svg'>, 'viewBox'>
+) => (
+  <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <desc>clipboard icon</desc>
+    <rect
+      fill="none"
+      stroke="black"
+      strokeWidth={1.25}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      width="8"
+      height="12"
+      x="5"
+      y="3"
+    />
+    <path
+      fill="none"
+      stroke="black"
+      strokeWidth={1.25}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M 10,1 H 3 v 8 0"
+    />
+  </svg>
+);

--- a/src/components/Button/CopyButton/index.ts
+++ b/src/components/Button/CopyButton/index.ts
@@ -1,0 +1,1 @@
+export * from './CopyButton';

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { Popover } from './Popover';
+
+export default {
+  component: Popover,
+} as ComponentMeta<typeof Popover>;
+
+const Template: ComponentStory<typeof Popover> = (args) => (
+  <Popover {...args}>
+    <div className="border border-solid border-black">Click here</div>
+  </Popover>
+);
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const popover = Template.bind({});
+popover.args = {
+  popup: 'Popover text',
+  disable: false,
+};

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+import { ComponentPropsWithoutRef, ReactNode, useState } from 'react';
+
+export const Popover = ({
+  popup,
+  disable,
+  className,
+  children,
+  ...restProps
+}: { popup: ReactNode; disable?: boolean } & Omit<
+  ComponentPropsWithoutRef<'div'>,
+  'onClick'
+>) => {
+  const [isActive, setIsActive] = useState(false);
+  const handleClick = () => {
+    if (!disable) {
+      setIsActive(true);
+      setTimeout(() => setIsActive(false), 3000);
+    }
+  };
+
+  return (
+    <div className="relative w-max" onClick={handleClick} {...restProps}>
+      <div
+        className={clsx(
+          'absolute top-[-0.125rem] left-1/2 w-max translate-x-[-50%] select-none text-[0.75rem]',
+          !disable && isActive ? 'animate-popup' : 'hidden',
+          className
+        )}
+        aria-hidden
+      >
+        {popup}
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/src/components/Popover/index.ts
+++ b/src/components/Popover/index.ts
@@ -1,0 +1,1 @@
+export * from './Popover';

--- a/src/hooks/useClipboard/index.ts
+++ b/src/hooks/useClipboard/index.ts
@@ -1,0 +1,2 @@
+export * from './useClipboardLink';
+export * from './useClipboardText';

--- a/src/hooks/useClipboard/useClipboardLink.ts
+++ b/src/hooks/useClipboard/useClipboardLink.ts
@@ -1,0 +1,13 @@
+/**
+ * @param {String} link copy link
+ * @param {String} text display text when hyper link
+ */
+export const useClipboardLink = (link: string, text?: string) => () =>
+  navigator.clipboard.write([
+    new ClipboardItem({
+      ['text/plain']: new Blob([link], { type: 'text/plain' }),
+      ['text/html']: new Blob([`<a href=${link}>${text || link}</a>`], {
+        type: 'text/html',
+      }),
+    }),
+  ]);

--- a/src/hooks/useClipboard/useClipboardText.ts
+++ b/src/hooks/useClipboard/useClipboardText.ts
@@ -1,0 +1,6 @@
+export const useClipboardText = (text: string) => () =>
+  navigator.clipboard.write([
+    new ClipboardItem({
+      ['text/plain']: new Blob([text], { type: 'text/plain' }),
+    }),
+  ]);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,33 @@
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        popup: {
+          '0%': {
+            transform: 'translate(-50%, 0)',
+            opacity: 0,
+            display: 'flex',
+          },
+          '25%': {
+            transform: 'translate(-50%, -100%)',
+            opacity: 1,
+          },
+          '75%': {
+            transform: 'translate(-50%, -100%)',
+            opacity: 1,
+          },
+          '100%': {
+            transform: 'translate(-50%, 0)',
+            opacity: 0,
+            display: 'none',
+          },
+        },
+      },
+      animation: {
+        popup: 'popup 3s',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
`footer`のコピーボタンも機能実装がまだでしたので、`CopyButton`として、またその中で`useClipboardLink`を実装しました。

- `CopyButton`
こうがく祭公式サイトへのリンクをコピーするボタン
コピーボタンに汎用性が必要ない（公式リンクコピーしか実装しない）なら、リンクなどを固定化しようと思います。
- `useClipboardLink`
リンクをコピーする関数を返す`hook`
リンクのプレーンテキストと、ハイパーリンクをコピーする
他所でコピーする箇所がないなら、`hook`化せずに、`CopyButton`内に直書きしようかと
- `useClipboardText`
テキストをコピーする
同上

リンクコピーの機能（特にハイパーリンク）は`.docs`などで試すとわかると思います。

コピー時のエフェクトは、要らないまたはデザイン変更などありましたら、お伝えください。