### PR TITLE
画像パス：`import`→`src`へ統一 #50

### DIFF
--- a/src/components/Button/MenuButton/MenuButton.tsx
+++ b/src/components/Button/MenuButton/MenuButton.tsx
@@ -1,5 +1,6 @@
 import menuIcon from '@public/rhino_soldering.png';
 import clsx from 'clsx';
+import { useMobileView } from 'hooks/useMobileView';
 import { useToggleMenu } from 'hooks/useToggleMenu';
 import Image from 'next/image';
 import { ComponentPropsWithoutRef } from 'react';
@@ -10,6 +11,7 @@ export const MenuButton = ({
   ...restProps
 }: ComponentPropsWithoutRef<'button'>) => {
   const toggleMenu = useToggleMenu();
+  const isMobile = useMobileView();
 
   return (
     <button
@@ -26,11 +28,12 @@ export const MenuButton = ({
       <span className="absolute top-0.5 left-1.5 z-10 text-center text-xs font-bold leading-3 text-gray-800 sm:top-1 sm:left-4 sm:w-20 sm:text-2xl sm:leading-7">
         MENU
       </span>
-      <div className="box-border h-12 w-12 rounded-sm border border-gray-400 p-1 sm:h-28 sm:w-28 sm:p-2">
+      <div className="box-border flex h-12 w-12 items-center justify-center rounded-sm border  border-gray-400 sm:h-28 sm:w-28">
         <Image
-          src={menuIcon}
+          src="/rhino_soldering.png"
+          width={isMobile ? 40 : 94}
+          height={isMobile ? 40 : 94}
           alt="menuIcon"
-          className="box-border h-full w-full"
         />
       </div>
     </button>

--- a/src/components/Landing/Landing.tsx
+++ b/src/components/Landing/Landing.tsx
@@ -2,10 +2,6 @@ import Image from 'next/image';
 import { RoundedButton } from 'components/Button';
 import { CountDown } from 'components/CountDown';
 import { useMobileView } from 'hooks/useMobileView';
-import KougakusaiTitle from '@public/kougakusai_title.png';
-import RhinoHappi from '@public/rhino_happi.png';
-import RhinoMachine from '@public/rhino_machine.png';
-import UnivLogo from '@public/univ_logo.png';
 
 export const Landing = () => {
   const isMobile = useMobileView();
@@ -15,7 +11,7 @@ export const Landing = () => {
     <div className="w-full bg-[url('/background_lines.png')] bg-cover bg-bottom text-center">
       <div className="relative top-[-32px] left-1/2 translate-x-[-50%] rotate-[-142deg] sm:top-[-48px]">
         <Image
-          src={RhinoHappi}
+          src="/rhino_happi.png"
           alt="はっぴを着たこうがくサイ"
           width={isMobile ? 104 : 160}
           height={isMobile ? 104 : 160}
@@ -23,7 +19,7 @@ export const Landing = () => {
       </div>
       <div>
         <Image
-          src={UnivLogo}
+          src="/univ_logo.png"
           alt="茨城大学のロゴマーク"
           width={isMobile ? 80 : 160}
           height={isMobile ? 50 : 100}
@@ -31,7 +27,7 @@ export const Landing = () => {
       </div>
       <div>
         <Image
-          src={KougakusaiTitle}
+          src="/kougakusai_title.png"
           alt="こうがく祭"
           width={isMobile ? 300 : 600}
           height={isMobile ? 170 : 340}
@@ -41,7 +37,7 @@ export const Landing = () => {
       <RoundedButton className="mt-[32px]">詳しくみる</RoundedButton>
       <div className="sm:mt-[-400px]">
         <Image
-          src={RhinoMachine}
+          src="/rhino_machine.png"
           alt="宇宙サイの宇宙船"
           width={isMobile ? 400 : 1440}
           height={isMobile ? 240 : 760}


### PR DESCRIPTION
### #50 ビルド時に余計なファイルを生成しないための画像パス統一

`images.stories.tsx`のパスは`import`方式だと、`Storybook`で画像の詳細（`src`・`width`・`height`）がみられるので、変更していませんが、これも変更しますか？