### PR TITLE
お問い合わせページ実装 #86

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -46,7 +46,10 @@ export const Footer = ({
         </SmallLink> */}
         <Small>感染症対策ガイドライン</Small>
       </div>
-      <LinkButton className="mt-[40px] bg-[#18283F] font-bold text-white">
+      <LinkButton
+        className="mt-[40px] bg-[#18283F] font-bold text-white"
+        href="/contact"
+      >
         お問い合わせ
       </LinkButton>
       <Copyright className="mt-[40px] block pb-[16px]" />

--- a/src/components/Layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/components/Layouts/DefaultLayout/DefaultLayout.tsx
@@ -11,13 +11,13 @@ export const DefaultLayout = ({
   pageTitle: string;
   children: ReactNode;
 }) => (
-  <>
+  <div className="flex min-h-screen flex-col">
     <Header className="z-20" />
     <MenuDrawer className="z-10" />
-    <div className="pt-[80px]">
-      <Heading className="text-center">{pageTitle}</Heading>
-      <div className="mx-auto my-[32px] w-[90%] max-w-[800px]">{children}</div>
-      <Copyright className="block pb-[24px] text-center" />
+    <Heading className="pt-[80px] text-center">{pageTitle}</Heading>
+    <div className="mx-auto my-[32px] w-[90%] max-w-[800px] flex-1">
+      {children}
     </div>
-  </>
+    <Copyright className="block pb-[24px] text-center" />
+  </div>
 );

--- a/src/components/Menu/MenuDrawer/MenuDrawer.tsx
+++ b/src/components/Menu/MenuDrawer/MenuDrawer.tsx
@@ -62,7 +62,8 @@ export const MenuDrawer = ({
         </li>
         {links.map(
           (link, i) =>
-            i !== 0 && (
+            i !== 0 &&
+            i !== 4 && (
               <li key={link.href}>
                 <p className="font-[Roboto] text-[1.5rem] font-bold leading-7 text-[#18283f] sm:text-[2.5rem] sm:leading-[3rem]">
                   {link.name}
@@ -70,6 +71,7 @@ export const MenuDrawer = ({
               </li>
             )
         )}
+        <MenuLink href={links[4].href}>{links[4].name}</MenuLink>
       </ul>
       <div className="mt-auto">
         <div className="mt-[40px] sm:mt-[120px]">

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,32 @@
+import type { NextPageWithLayout } from 'pages/_app';
+import Head from 'next/head';
+import { DefaultLayout } from 'components/Layouts/DefaultLayout';
+import { Paragraph } from 'components/Typography';
+
+const Contect: NextPageWithLayout = () => {
+  return (
+    <>
+      <Head>
+        <title>お問い合わせ | 2022年度こうがく祭公式HP</title>
+      </Head>
+
+      <main>
+        <Paragraph className="font-bold">茨城大学工学部キャンパス</Paragraph>
+        <Paragraph className="mt-[8px]">
+          &#12306;316-8511&nbsp;茨城県日立市中成沢町4-12-1
+        </Paragraph>
+        <br />
+        <Paragraph className="font-bold">E-mail</Paragraph>
+        <Paragraph className="mt-[8px]">
+          koho.kougakusai@ml.ibaraki.ac.jp
+        </Paragraph>
+      </main>
+    </>
+  );
+};
+
+Contect.getLayout = (page) => (
+  <DefaultLayout pageTitle="お問い合わせ">{page}</DefaultLayout>
+);
+
+export default Contect;


### PR DESCRIPTION
Close #86 .

お問い合わせページを実装しました。

ただし、`DefaultLayout`にて、コンテンツが少ない場合でもフッタがページ最下部になるように修正しました。
また、トップページやメニューからお問い合わせページへ遷移できるように修正しました。