### PR TITLE
`TwitterTimeline`：追加 #118

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -8,6 +8,7 @@ import { LinkButton } from 'components/Button';
 import { InstagramIcon, TwitterIcon, YoutubeIcon } from 'components/Icon';
 import { CopyButton } from 'components/Button/CopyButton';
 import { FacebookIcon } from 'components/Icon/FacebookIcon';
+import { TwitterTimeline } from 'components/TwitterTimeline';
 
 export const Footer = ({
   className,
@@ -38,7 +39,7 @@ export const Footer = ({
           ))}
           <CopyButton />
         </div>
-        {/* TODO: embed twitter timeline */}
+        <TwitterTimeline />
         <Heading>茨城大学工学部公式SNS</Heading>
         <div className="flex h-10 justify-center gap-x-6">
           {CoESNSLinks.map(({ name, href, icon }) => (

--- a/src/components/TwitterTimeline/TwitterTimeline.stories.tsx
+++ b/src/components/TwitterTimeline/TwitterTimeline.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { TwitterTimeline } from './TwitterTimeline';
+
+export default {
+  component: TwitterTimeline,
+} as ComponentMeta<typeof TwitterTimeline>;
+
+const Template: ComponentStory<typeof TwitterTimeline> = (args) => (
+  <TwitterTimeline {...args} />
+);
+
+// eslint-disable-next-line storybook/prefer-pascal-case
+export const twitterTimeline = Template.bind({});
+twitterTimeline.args = {};

--- a/src/components/TwitterTimeline/TwitterTimeline.tsx
+++ b/src/components/TwitterTimeline/TwitterTimeline.tsx
@@ -9,7 +9,12 @@ export const TwitterTimeline = ({
 }: ComponentPropsWithoutRef<'section'>) => {
   useEffect(() => {
     const twitterScript = window.document.createElement('script');
-    twitterScript.src = 'https://platform.twitter.com/widgets.js';
+    twitterScript.setAttribute(
+      'src',
+      'https://platform.twitter.com/widgets.js'
+    );
+    twitterScript.setAttribute('async', '');
+    twitterScript.setAttribute('charset', 'utf-8');
     window.document
       .getElementsByClassName('twitter-timeline')[0]
       .before(twitterScript);
@@ -20,17 +25,17 @@ export const TwitterTimeline = ({
       className={clsx('flex flex-auto justify-center', className)}
       {...restProps}
     >
-      <div className="m-4 flex h-[37rem] w-[37.5rem] min-w-[20rem] shrink overflow-auto rounded-xl">
+      <div className="m-4 flex max-h-[37rem] min-h-[1rem] w-[37.5rem] min-w-[20rem] shrink flex-col overflow-auto">
         <a
           href="https://twitter.com/kougakufes?ref_src=twsrc%5Etfw"
           // eslint-disable-next-line tailwindcss/no-custom-classname
-          className="twitter-timeline"
+          className="twitter-timeline underline"
           target="_blank"
           data-lang="ja"
           data-dnt="true"
           rel="noopener noreferrer"
         >
-          Tweets by kougakufes
+          こうがく祭公式Twitterタイムライン
         </a>
       </div>
     </section>

--- a/src/components/TwitterTimeline/TwitterTimeline.tsx
+++ b/src/components/TwitterTimeline/TwitterTimeline.tsx
@@ -1,0 +1,38 @@
+import clsx from 'clsx';
+import { ComponentPropsWithoutRef, useEffect } from 'react';
+
+/*  https://publish.twitter.com/?dnt=1&lang=ja&query=https%3A%2F%2Ftwitter.com%2Fkougakufes&widget=Timeline
+    https://dev.to/heymarkkop/embed-twitter-widget-on-reactjs-1768   */
+export const TwitterTimeline = ({
+  className,
+  ...restProps
+}: ComponentPropsWithoutRef<'section'>) => {
+  useEffect(() => {
+    const twitterScript = window.document.createElement('script');
+    twitterScript.src = 'https://platform.twitter.com/widgets.js';
+    window.document
+      .getElementsByClassName('twitter-timeline')[0]
+      .before(twitterScript);
+  }, []);
+
+  return (
+    <section
+      className={clsx('flex flex-auto justify-center', className)}
+      {...restProps}
+    >
+      <div className="m-4 flex h-[37rem] w-[37.5rem] min-w-[20rem] shrink overflow-auto rounded-xl">
+        <a
+          href="https://twitter.com/kougakufes?ref_src=twsrc%5Etfw"
+          // eslint-disable-next-line tailwindcss/no-custom-classname
+          className="twitter-timeline"
+          target="_blank"
+          data-lang="ja"
+          data-dnt="true"
+          rel="noopener noreferrer"
+        >
+          Tweets by kougakufes
+        </a>
+      </div>
+    </section>
+  );
+};

--- a/src/components/TwitterTimeline/index.ts
+++ b/src/components/TwitterTimeline/index.ts
@@ -1,0 +1,1 @@
+export * from './TwitterTimeline';


### PR DESCRIPTION
[公式埋め込みツール](https://publish.twitter.com/?dnt=1&lang=ja&query=https%3A%2F%2Ftwitter.com%2Fkougakufes&widget=Timeline)を使用。
`Desktop版`は`公式Web版Client`の幅と同じにしました。