### PR TITLE
`iPhone`で`svg`が表示されない：修正 #161

### DIFF
--- a/src/components/Icon/ClipboardIcon/ClipboardIcon.tsx
+++ b/src/components/Icon/ClipboardIcon/ClipboardIcon.tsx
@@ -3,7 +3,13 @@ import { ComponentPropsWithoutRef } from 'react';
 export const ClipboardIcon = (
   props: Omit<ComponentPropsWithoutRef<'svg'>, 'viewBox'>
 ) => (
-  <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" {...props}>
+  <svg
+    viewBox="0 0 16 16"
+    width="100%"
+    height="100%"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
     <desc>clipboard icon</desc>
     <rect
       fill="none"

--- a/src/components/Icon/FacebookIcon/FacebookIcon.tsx
+++ b/src/components/Icon/FacebookIcon/FacebookIcon.tsx
@@ -1,13 +1,13 @@
 import { ComponentPropsWithoutRef } from 'react';
 
-export const FacebookIcon = ({
-  className,
-  ...restProps
-}: Omit<ComponentPropsWithoutRef<'svg'>, 'viewBox'>) => (
+export const FacebookIcon = (
+  props: Omit<ComponentPropsWithoutRef<'svg'>, 'viewBox'>
+) => (
   <svg
     viewBox="0 0 1365.3333 1365.3333"
-    className={`h-full w-full ${className}`}
-    {...restProps}
+    width="100%"
+    height="100%"
+    {...props}
     xmlns="http://www.w3.org/2000/svg"
   >
     <desc>Facebook Icon</desc>

--- a/src/components/Icon/InstagramIcon/InstagramIcon.tsx
+++ b/src/components/Icon/InstagramIcon/InstagramIcon.tsx
@@ -1,13 +1,11 @@
 import { ComponentPropsWithoutRef } from 'react';
 
-export const InstagramIcon = ({
-  className,
-  ...restProps
-}: ComponentPropsWithoutRef<'svg'>) => (
+export const InstagramIcon = (props: ComponentPropsWithoutRef<'svg'>) => (
   <svg
     viewBox="0 0 1005 1005"
-    className={`h-full w-full ${className}`}
-    {...restProps}
+    width="100%"
+    height="100%"
+    {...props}
     xmlns="http://www.w3.org/2000/svg"
   >
     <desc>Instagram Icon</desc>

--- a/src/components/Icon/TwitterIcon/TwitterIcon.tsx
+++ b/src/components/Icon/TwitterIcon/TwitterIcon.tsx
@@ -7,6 +7,8 @@ export const TwitterIcon = ({
   <svg
     viewBox="0 0 248 204"
     className={`aspect-square h-full w-full ${className}`}
+    width="100%"
+    height="100%"
     {...restProps}
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/src/components/Icon/YouTubeIcon/YouTubeIcon.tsx
+++ b/src/components/Icon/YouTubeIcon/YouTubeIcon.tsx
@@ -1,13 +1,11 @@
 import { ComponentPropsWithoutRef } from 'react';
 
-export const YoutubeIcon = ({
-  className,
-  ...restProps
-}: ComponentPropsWithoutRef<'svg'>) => (
+export const YoutubeIcon = (props: ComponentPropsWithoutRef<'svg'>) => (
   <svg
     viewBox="0 0 256 256"
-    className={`h-full w-full ${className}`}
-    {...restProps}
+    width="100%"
+    height="100%"
+    {...props}
     xmlns="http://www.w3.org/2000/svg"
   >
     <desc>Youtube Icon</desc>


### PR DESCRIPTION
`svg`タグへ`width (="100%)`・ `height (="100%)`を追加しました。

@`iPhone`をお持ちの方
確認お願いします。

P.S 元の状態で、`Menu`の`Map Pin アイコン`は表示されていますか？確認したいです。

ref: [iOS / Mac Safari で display: flex の中の svg が表示されない](https://teratail.com/questions/8l2ao6madzfkxt)