### PR TITLE
更新時にエラーが出る #112

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+Dockerfile
+.dockerignore
+node_modules
+out
+.git
+.gitignore
+.next
+.storybook
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
+
+# node_modules をインストール
+FROM node:16-alpine AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# アプリケーションをビルド
+FROM node:16-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN yarn export
+
+# Apache で配信
+FROM httpd:2.4-alpine
+COPY --from=builder /app/out /usr/local/apache2/htdocs

--- a/README.md
+++ b/README.md
@@ -11,3 +11,42 @@
 ## デザイン
 
 [Figma](https://www.figma.com/file/iFbg1zLpfO1qfiAkTi1c0z/HP?node-id=0%3A1)
+
+## 実行方法
+
+### SSR
+
+```sh
+$ yarn install
+$ yarn dev
+```
+
+ブラウザで[localhost:3000](http://localhost:3000)にアクセスすることで閲覧可能。
+
+### SSG
+
+```sh
+$ yarn install
+$ yarn start
+```
+
+ブラウザで[localhost:3000](http://localhost:3000)にアクセスすることで閲覧可能。
+
+### Storybook
+
+```sh
+$ yarn install
+$ yarn storybook
+```
+
+ブラウザで[localhost:6006](http://localhost:6006)にアクセスすることで閲覧可能。
+
+### export
+
+```sh
+$ docker build -t kougakusai-hp2022 .
+$ docker run -p 3000:80 kougakusai-hp2022
+```
+
+Next.js が出力した静的ファイルを Apache で配信する。
+ブラウザで[localhost:3000](http://localhost:3000)にアクセスすることで閲覧可能。

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
   images: {
     path: process.env.NEXT_PUBLIC_BASE_PATH + '/_next/image',
   },
+  trailingSlash: true,
   experimental: {
     images: {
       unoptimized: true,


### PR DESCRIPTION
# エラー内容
トップページ以外のページでブラウザをリロードすると404または403になる。

# 再現手順
1. `next.config.js`の`trailingSlash`を`false`にする
2. README の手順に従い docker コンテナを起動
3. ブラウザで localhost:3000 にアクセスし、トップページ以外の任意のページでリロード
（404や403にはならないが適切な html が返却されていないことが分かる）

# 原因
例えば`/program`でリロードすると`/program/index.html`を取得しようとする。
しかし、`trailingSlash`が`false`だと Next.js は`/program.html`を生成するため`/program/index.html`が見つからない。

# 解決策
`trailingSlash`を`true`に設定し、`/program`を`/program/index.html`として生成するように修正。

Close #112 .