### PR TITLE
`企画一覧ページ`：デザイン変更 #172

### DIFF
--- a/src/components/ProgramItem/ProgramItem.tsx
+++ b/src/components/ProgramItem/ProgramItem.tsx
@@ -2,24 +2,7 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import { ComponentPropsWithoutRef, ReactNode } from 'react';
 import { InstagramIcon, TwitterIcon } from 'components/Icon';
-
-const InsideChip = () => (
-  <div
-    className="h-6 select-none whitespace-nowrap rounded-full bg-[#DCFCE7] px-3 text-center text-base text-[#16A34A]"
-    title="開催場所：屋内"
-  >
-    屋内
-  </div>
-);
-
-const StageChip = () => (
-  <div
-    className="h-6 select-none whitespace-nowrap rounded-full bg-[#DBEAFE] px-3 text-center text-base text-[#1D4ED8]"
-    title="開催場所：ステージ"
-  >
-    ステージ
-  </div>
-);
+import { Paragraph } from 'components/Typography';
 
 const PlaceChip = ({ place }: { place: string }) => (
   <div
@@ -35,6 +18,15 @@ const PlaceChip = ({ place }: { place: string }) => (
   </div>
 );
 
+const RegistrationChip = () => (
+  <div
+    className="h-6 select-none whitespace-nowrap rounded-full bg-[#FEE2E2] px-3 text-center text-base text-[#DC2626]"
+    title="事前申し込みが必要"
+  >
+    事前申し込み
+  </div>
+);
+
 type ProgramData = {
   programName: string;
   groupName: string;
@@ -44,47 +36,48 @@ type ProgramData = {
   groupLink?: string;
   twitter?: string;
   instagram?: string;
+  registration?: boolean;
 };
 
 export const ProgramItem = ({
   data,
   className,
   ...restProps
-}: { data: ProgramData } & ComponentPropsWithoutRef<'div'>) => (
-  <div
+}: { data: ProgramData } & ComponentPropsWithoutRef<'section'>) => (
+  <section
     className={clsx(
-      'inline-flex flex-col gap-y-2 rounded-lg bg-white p-4 font-[Roboto] text-[#18283F]',
+      'grid gap-y-4 rounded-lg bg-white p-4 font-[Roboto] text-[#18283F]',
       className
     )}
     {...restProps}
   >
-    <div className="flex justify-between gap-x-2">
+    <div className=" grid grid-flow-col grid-rows-2 gap-2 [grid-template-columns:1fr_auto;]">
       <h4
         className="overflow-hidden text-ellipsis whitespace-nowrap text-base font-bold"
         title={data.programName}
       >
         {data.programName}
       </h4>
-      {/* {place === 'inside' ? <InsideChip /> : <StageChip />} */}
-      <PlaceChip place={data.place} />
-    </div>
-    {data.groupLink ? (
-      <a
-        href={data.groupLink}
-        title={`${data.groupName}のサイトへ`}
-        target="_blank"
-        className="underline"
-        rel="noreferrer"
-      >
+      {data.groupLink ? (
+        <a
+          href={data.groupLink}
+          title={`${data.groupName}のサイトへ`}
+          target="_blank"
+          className="underline"
+          rel="noreferrer"
+        >
+          <h5 className="overflow-hidden text-ellipsis whitespace-nowrap">
+            {data.groupName}
+          </h5>
+        </a>
+      ) : (
         <h5 className="overflow-hidden text-ellipsis whitespace-nowrap">
           {data.groupName}
         </h5>
-      </a>
-    ) : (
-      <h5 className="overflow-hidden text-ellipsis whitespace-nowrap">
-        {data.groupName}
-      </h5>
-    )}
+      )}
+      {data.registration && <RegistrationChip />}
+      <PlaceChip place={data.place} />
+    </div>
     {data.image && (
       <div className="h-[3.75rem]">
         <Image
@@ -96,9 +89,11 @@ export const ProgramItem = ({
         />
       </div>
     )}
-    <div className="overflow-hidden text-ellipsis whitespace-pre-line">
-      {data.introduction}
-    </div>
+    {typeof data.introduction === 'string' ? (
+      <Paragraph>{data.introduction}</Paragraph>
+    ) : (
+      <div>{data.introduction}</div>
+    )}
 
     <div className="flex items-center justify-end gap-x-4">
       {data.instagram && (
@@ -122,5 +117,5 @@ export const ProgramItem = ({
         </a>
       )}
     </div>
-  </div>
+  </section>
 );

--- a/src/data/program/program.tsx
+++ b/src/data/program/program.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 const student = {
   variety: '学生企画',
@@ -791,7 +791,20 @@ const openLabCis = {
 //   ],
 // };
 
-export const programData = [
+export const programData: {
+  variety: string;
+  data: {
+    programName: string;
+    groupName: string;
+    place: string;
+    introduction?: string | ReactNode;
+    image?: string;
+    groupLink?: string;
+    twitter?: string;
+    instagram?: string;
+    registration?: boolean;
+  }[];
+}[] = [
   student,
   teacher,
   local,
@@ -804,4 +817,47 @@ export const programData = [
   openLabEes,
   openLabMsae,
   openLabCis,
+];
+
+export const stageProgramList = [
+  {
+    start: '10:30',
+    title: '日立第二高等学校演劇部',
+  },
+  {
+    start: '11:00',
+    title: '中南米音楽研究会日立支部',
+  },
+  {
+    start: '11:30',
+    title: '学生フォーミュラカーの走行と展示',
+  },
+  {
+    start: '12:00',
+    title: '茨城大学吹奏楽団日立支部',
+  },
+  {
+    start: '12:30',
+    title: '中南米音楽研究会日立支部',
+  },
+  {
+    start: '13:00',
+    title: '学生フォーミュラカーの走行と展示',
+  },
+  {
+    start: '13:30',
+    title: 'Cherry’s ダンスステージ',
+  },
+  {
+    start: '14:00',
+    title: 'ビンゴ大会',
+  },
+  {
+    start: '14:30',
+    title: '学生フォーミュラカーの走行と展示',
+  },
+  {
+    start: '15:00',
+    title: '大道芸サークルスウェット組合',
+  },
 ];

--- a/src/pages/program.tsx
+++ b/src/pages/program.tsx
@@ -1,25 +1,86 @@
 import type { NextPageWithLayout } from 'pages/_app';
 import Head from 'next/head';
 import { DefaultLayout } from 'components/Layouts/DefaultLayout';
-import { programData } from 'data/program';
+import { programData, stageProgramList } from 'data/program';
 import { ProgramItem } from 'components/ProgramItem';
+import { ComponentPropsWithoutRef, ReactNode } from 'react';
+import clsx from 'clsx';
+import { Paragraph } from 'components/Typography';
+
+const Section = ({
+  head,
+  children,
+  className,
+  ...restProps
+}: { head?: string } & ComponentPropsWithoutRef<'section'>) => (
+  <section
+    className={clsx(
+      'rounded-lg bg-white p-4 font-[Roboto] text-[#18283F]',
+      className
+    )}
+    {...restProps}
+  >
+    {head && <h2 className="mb-4 text-base font-bold">{head}</h2>}
+    {children}
+  </section>
+);
 
 const Program: NextPageWithLayout = () => {
+  const registProgram: {
+    programName: string;
+    groupName: string;
+    place: string;
+    introduction?: ReactNode;
+    image?: string | undefined;
+    groupLink?: string | undefined;
+    twitter?: string | undefined;
+    instagram?: string | undefined;
+    registration?: boolean | undefined;
+  }[] = [];
+  programData.forEach((programCategory) => {
+    registProgram.push(
+      ...programCategory.data.filter((program) => program.registration)
+    );
+  });
   return (
     <>
       <Head>
         <title>企画一覧 | 2022年度こうがく祭公式HP</title>
       </Head>
 
-      <main className="flex flex-col gap-y-4 divide-y-2">
-        {programData.map((program) => (
-          <section className="flex flex-col gap-6" key={program.variety}>
-            <h3>{program.variety}</h3>
-            {program.data.map((item) => (
-              <ProgramItem data={item} key={item.groupName} />
+      <main className="grid gap-y-6">
+        <Section head="企画">
+          <a
+            href="/program/企画一覧.pdf"
+            className="font-[Roboto] text-[#18283F] underline"
+          >
+            企画一覧
+          </a>
+        </Section>
+        <Section head="ステージ企画">
+          <table className="font-[Roboto] text-base text-[#18283F]">
+            <tbody>
+              {stageProgramList.map((program) => (
+                <tr className="h-5 align-top" key={program.start}>
+                  <td className="w-16">{program.start}～</td>
+                  <td className="">{program.title}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Section>
+        <Section head="スタンプラリー">
+          スタンプラリー企画詳細は後日掲載予定
+          {/* TODO:<Link href="/program/stamp/"><a className="underline">スタンプラリー企画詳細ページ</a></Link> */}
+        </Section>
+        {!!registProgram.length && (
+          <section className="grid gap-y-4">
+            <Paragraph>以下の企画は事前の申し込みが必要です。</Paragraph>
+            {registProgram.map((program) => (
+              <ProgramItem data={program} key={program.programName} />
             ))}
           </section>
-        ))}
+        )}
       </main>
     </>
   );


### PR DESCRIPTION
`PDFファイル`は`a`タグで、開くようにしています。（`iFrame`も可）
`PDFファイル`が合っているか確認お願いします。（最終版ではない場合は、`Issue`を立てておいてください）

事前申し込み必須企画データの追加はしていません。（表示には対応しました。）