### PR TITLE
協賛企業URL：追加（11/01） #212

### DIFF
--- a/src/data/sponsor/sponsor.ts
+++ b/src/data/sponsor/sponsor.ts
@@ -110,7 +110,7 @@ export const sponsorData: sponsorDataType = [
   },
   {
     name: '株式会社学情',
-    link: 'https://company.gakujo.ne.jp/',
+    link: 'https://x.gd/ibaraki2022/',
     kana: 'カブシキガイシャ　ガクジョウ',
   },
   {
@@ -305,6 +305,7 @@ export const sponsorData: sponsorDataType = [
   },
   {
     name: '放課後児童クラブKusuKusu',
+    link: 'http://www.kusu2.jp/',
     kana: 'ホウカゴジドウクラブ　KusuKusu',
   },
 ].sort((a, b) => (a.kana || a.name).localeCompare(b.kana || b.name, 'ja'));

--- a/src/data/sponsor/sponsor.ts
+++ b/src/data/sponsor/sponsor.ts
@@ -21,7 +21,7 @@ export const sponsorData: sponsorDataType = [
   {
     name: 'Honda Cars 日立南 金沢店',
     link: 'https://dealer.honda.co.jp/hondacars-hitachiminami/',
-    kana: 'Honda Cars ヒタチミナミ　カナザワテン',
+    kana: 'Honda Cars ヒタチミナミ　カネサワテン',
   },
   {
     name: 'アイ・イー・シー株式会社',


### PR DESCRIPTION
> 株式会社学情(https://x.gd/ibaraki2022)

リンク先が`404`になっていますが良いでしょうか？


`Slack`で指摘のあった読み仮名の修正も含みます。